### PR TITLE
Add const_unsafe_cell_new feature flag for nightly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![deny(missing_docs)]
 #![deny(warnings)]
-#![feature(const_fn)]
+#![feature(const_fn,const_unsafe_cell_new)]
 #![no_std]
 
 use core::cell::UnsafeCell;


### PR DESCRIPTION
Fixes build failure:

```
error: `<core::cell::UnsafeCell<T>>::new` is not yet stable as a const fn
  --> /.../.cargo/registry/src/github.com-1ecc6299db9ec823/bare-metal-0.1.0/src/lib.rs:63:24
   |
63 |         Mutex { inner: UnsafeCell::new(value) }
   |                        ^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: in Nightly builds, add `#![feature(const_unsafe_cell_new)]` to the crate attributes to enable

error: aborting due to previous error

error: Could not compile `bare-metal`.
```