### PR TITLE
Add borrow_mut function to Mutex

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,6 +93,11 @@ impl<T> Mutex<T> {
     pub fn borrow<'cs>(&self, _cs: &'cs CriticalSection) -> &'cs T {
         unsafe { &*self.inner.get() }
     }
+
+    /// Borrows the data mutably for the duration of the critical section
+    pub fn borrow_mut<'cs>(&self, _cs: &'cs CriticalSection) -> &'cs mut T {
+        unsafe { &mut *self.inner.get() }
+    }
 }
 
 /// Interrupt number


### PR DESCRIPTION
I have encountered points where I would like a mutable reference from a `Mutex` and have chafed at the lack of a way of getting one. I have in the past placed a `RefCell` inside the `Mutex` to get around this, but this is just placing on `UnsafeCell` needlessly inside another. This PR simply adds a `borrow_mut` function to fill this hole in the API. 