### PR TITLE
Remove old unstable feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 #![deny(warnings)]
 #![cfg_attr(
     feature = "const-fn",
-    feature(const_fn, const_unsafe_cell_new)
+    feature(const_fn)
 )]
 #![no_std]
 


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/46287 removed this feature a while back, https://github.com/rust-lang/rust/pull/52644 has now made it a hard error to refer to a non-existing feature so `bare-metal` with `const-fn` feature active does not compile on the latest nightly (2018-08-13).